### PR TITLE
fix: defensive code to handle multiple overlapping restart requests

### DIFF
--- a/src/main/http.js
+++ b/src/main/http.js
@@ -57,6 +57,8 @@ export class HttpMonitor {
           return res.sendStatus(404)
         }
 
+        log.info(`[${props.id}] received HTTP control message : stop`)
+
         props.stop()
         res.send({})
       })
@@ -67,6 +69,8 @@ export class HttpMonitor {
           return res.sendStatus(404)
         }
 
+        log.info(`[${props.id}] received HTTP control message : start`)
+
         props.start()
         res.send({})
       })
@@ -76,6 +80,8 @@ export class HttpMonitor {
         if (!props) {
           return res.sendStatus(404)
         }
+
+        log.info(`[${props.id}] received HTTP control message : restart`)
 
         props.restart()
         res.send({})


### PR DESCRIPTION
Tested with `curl -vvv -X POST localhost:8005/processes/casparcg/restart`.

Log for 6 overlapping restart requests is now:

```
[2019-04-26 11:56:13.504] [info] [casparcg] ping timer starting
[2019-04-26 11:57:30.249] [info] [casparcg] received HTTP control message : restart
[2019-04-26 11:57:30.335] [info] [casparcg] received HTTP control message : restart
[2019-04-26 11:57:30.336] [info] [casparcg] attempt to restart whilst already restarting
[2019-04-26 11:57:30.413] [info] [casparcg] received HTTP control message : restart
[2019-04-26 11:57:30.413] [info] [casparcg] attempt to restart whilst already restarting
[2019-04-26 11:57:30.478] [info] [casparcg] received HTTP control message : restart
[2019-04-26 11:57:30.479] [info] [casparcg] attempt to restart whilst already restarting
[2019-04-26 11:57:30.552] [info] [casparcg] received HTTP control message : restart
[2019-04-26 11:57:30.552] [info] [casparcg] attempt to restart whilst already restarting
[2019-04-26 11:57:30.560] [error] [casparcg] Error: read ECONNRESET
[2019-04-26 11:57:30.561] [info] [casparcg] ping connection closed
[2019-04-26 11:57:30.594] [info] [casparcg] casparcg.exe exit 1 null
[2019-04-26 11:57:30.594] [info] [casparcg] casparcg.exe stop
[2019-04-26 11:57:30.594] [info] [casparcg] stopping healthcheck
[2019-04-26 11:57:30.617] [info] [casparcg] received HTTP control message : restart
[2019-04-26 11:57:30.617] [info] [casparcg] attempt to restart whilst already restarting
[2019-04-26 11:57:31.601] [info] [casparcg] casparcg.exe spawn 50180
[2019-04-26 11:57:31.601] [info] [casparcg] starting healthcheck
[2019-04-26 11:57:31.601] [info] [casparcg] casparcg.exe start
[2019-04-26 11:57:36.602] [info] [casparcg] ping timer starting
```

If restart requests are spaced out over a few seconds, more than one restart will occur.