### PR TITLE
fix: Adding a static path

### DIFF
--- a/src/renderer/components/Settings.vue
+++ b/src/renderer/components/Settings.vue
@@ -167,10 +167,10 @@
         this.config = conf
 
         if (!this.config.api) {
-          this.config.api = {}
+          this.$set(this.config, 'api', {})
         }
         if (!this.config.api.staticPaths) {
-          this.config.api.staticPaths = []
+          this.$set(this.config.api, 'staticPaths', [])
         }
       })
       ipcRenderer.send('config.get')


### PR DESCRIPTION
This PR fixes an issue causing inability to add a Static Path in Settings when `api.staticPaths` doesn't exist in config.