### PR TITLE
fix: Set CWD to executable file directory

### DIFF
--- a/src/main/process.js
+++ b/src/main/process.js
@@ -86,9 +86,11 @@ export class ProcessMonitor {
       return
     }
 
+    const cwd = path.dirname(procPath)
+    const exeName = path.basename(procPath)
     const args = this.config.args || ''
-    this.process = respawn([this.config.exeName].concat(stringArgv(args)), {
-      cwd: basePath,
+    this.process = respawn([exeName].concat(stringArgv(args)), {
+      cwd,
     })
 
     this.process.on('start', () => {


### PR DESCRIPTION
This PR fixes how the CWD is set when spawning processes.
Currently the Base Path is always set as the CWD for the processes, which is fine as long as the executables reside in one directory, but when an absolute path or a relative path with some preceding directories is given in the Executable field, a processes that uses CWD to look for its config files etc., will still look in the Base Path instead of its actual directory.
This PR makes it so that the absolute path to the directory of the process executable is given as the CWD.